### PR TITLE
chore(ci): SHA-pin actions + add permissions block to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,16 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write  # softprops/action-gh-release creates the release; this step needs write
+
 jobs:
   release:
     runs-on: macos-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Build universal binary
         run: ./build.sh
@@ -30,7 +33,7 @@ jobs:
           echo "SHA256=$(shasum -a 256 ProgressIndicator-${VERSION}.tar.gz | cut -d' ' -f1)" >> $GITHUB_ENV
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3
         with:
           files: ProgressIndicator-*.tar.gz
           body: |


### PR DESCRIPTION
## Summary

Highest-priority items from the 2026-04-29 GitHub Actions audit (against patterns in [GitHub Actions Is The Weakest Link](https://nesbitt.io/2026/04/28/github-actions-is-the-weakest-link.html)).

This workflow has the largest blast radius across all 29 audited repos because:

- It runs with `HOMEBREW_TAP_TOKEN`, a fine-grained PAT with cross-repo write access to \`smartwatermelon/homebrew-tap\`.
- \`softprops/action-gh-release\` runs while that secret is in process env. A tag-pinned reference means a hijacked v3 tag would expose the token (the article notes 76 of 77 historical Trivy tags were hijacked — no publisher is exempt).

## Changes

- Add top-level \`permissions: { contents: write }\` (was relying on repo default; \`smartwatermelon/swift-progress-indicator\` defaults to read, so the release step would have been failing — verify on next tag push).
- Pin \`softprops/action-gh-release@v3\` → SHA \`b4309332981a82ec1c5618f44dd2e27cc8bfbfda\`
- Pin \`actions/checkout@v6\` → SHA \`de0fac2e4500dabe0009e67214ff5f5447ce83dd\`

Tag comments preserved so Dependabot keeps the SHAs current.

## Test plan

- [ ] Tag a new version after merge and confirm release publishes
- [ ] Confirm Homebrew cask update step still succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)